### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/cage.sh
+++ b/cage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="0.2.0"
+VERSION="0.4.0"
 IMAGE="${CAGE_IMAGE:-ghcr.io/pacificsky/devcontainer-lite:latest}"
 HOME_VOL="cage-home"
 

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -300,13 +300,13 @@ test_help_long_flag() {
     local out; out="$(run_cage --help)";  assert_contains "$out" "Usage:"
 }
 test_version_V() {
-    local out; out="$(run_cage -V)";      assert_contains "$out" "cage 0.2.0"
+    local out; out="$(run_cage -V)";      assert_contains "$out" "cage 0.4.0"
 }
 test_version_long() {
-    local out; out="$(run_cage --version)"; assert_contains "$out" "cage 0.2.0"
+    local out; out="$(run_cage --version)"; assert_contains "$out" "cage 0.4.0"
 }
 test_version_command() {
-    local out; out="$(run_cage version)"; assert_contains "$out" "cage 0.2.0"
+    local out; out="$(run_cage version)"; assert_contains "$out" "cage 0.4.0"
 }
 
 test_unknown_command_fails() {


### PR DESCRIPTION
## Summary
- Bumps `VERSION` in `cage.sh` from `0.2.0` to `0.4.0`
- The v0.3.0 release shipped with VERSION still set to 0.2.0 (missed update), so bumping straight to 0.4.0 to avoid confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)