### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/cage.sh
+++ b/cage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="0.5.0"
+VERSION="0.6.0"
 IMAGE="${CAGE_IMAGE:-ghcr.io/pacificsky/devcontainer-lite:latest}"
 HOME_VOL="cage-home"
 

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -308,13 +308,13 @@ test_help_long_flag() {
     local out; out="$(run_cage --help)";  assert_contains "$out" "Usage:"
 }
 test_version_V() {
-    local out; out="$(run_cage -V)";      assert_contains "$out" "cage 0.5.0"
+    local out; out="$(run_cage -V)";      assert_contains "$out" "cage 0.6.0"
 }
 test_version_long() {
-    local out; out="$(run_cage --version)"; assert_contains "$out" "cage 0.5.0"
+    local out; out="$(run_cage --version)"; assert_contains "$out" "cage 0.6.0"
 }
 test_version_command() {
-    local out; out="$(run_cage version)"; assert_contains "$out" "cage 0.5.0"
+    local out; out="$(run_cage version)"; assert_contains "$out" "cage 0.6.0"
 }
 
 test_unknown_command_fails() {


### PR DESCRIPTION
## Summary
- Bump version from 0.5.0 to 0.6.0 in `cage.sh` and update corresponding version tests

## Test plan
- [x] Unit tests updated to expect `cage 0.6.0`
- [ ] Verify `cage -V`, `cage --version`, and `cage version` all report 0.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)