### PR TITLE
Pass HOST_UID and HOST_GID to container

### DIFF
--- a/cage.sh
+++ b/cage.sh
@@ -181,6 +181,8 @@ cmd_enter() {
                 ${ssh_agent_args[@]+"${ssh_agent_args[@]}"} \
                 ${env_file_args[@]+"${env_file_args[@]}"} \
                 -e UV_PROJECT_ENVIRONMENT=.cage-venv \
+                -e HOST_UID="$(id -u)" \
+                -e HOST_GID="$(id -g)" \
                 -l "cage.project=${project_dir}" \
                 "$IMAGE" >/dev/null
 

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -1322,6 +1322,34 @@ test_start_no_env_files() {
     rm -rf "$project_dir"
 }
 
+test_start_passes_host_uid_gid() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 1 ""
+    mock_docker_response "pull" 0 ""
+    mock_docker_response "create" 0 ""
+    mock_docker_response "start" 0 ""
+    run_cage start >/dev/null 2>&1 || true
+    local calls; calls="$(mock_calls)"
+    local uid gid
+    uid="$(id -u)"
+    gid="$(id -g)"
+    assert_contains "$calls" "-e HOST_UID=${uid}" "HOST_UID env var in docker create"
+    assert_contains "$calls" "-e HOST_GID=${gid}" "HOST_GID env var in docker create"
+}
+
+test_reattach_does_not_pass_host_uid_gid() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 0 "true"
+    mock_docker_response "image" 1 ""
+    mock_docker_response "attach" 0 ""
+    run_cage start >/dev/null 2>&1 || true
+    local calls; calls="$(mock_calls)"
+    assert_not_contains "$calls" "HOST_UID" "no HOST_UID on reattach"
+    assert_not_contains "$calls" "HOST_GID" "no HOST_GID on reattach"
+}
+
 test_reattach_does_not_use_env_files() {
     mock_reset
     mock_docker_response "info" 0 ""
@@ -1486,6 +1514,8 @@ main() {
     run_test test_start_project_env_file
     run_test test_start_both_env_files
     run_test test_start_no_env_files
+    run_test test_start_passes_host_uid_gid
+    run_test test_reattach_does_not_pass_host_uid_gid
     run_test test_reattach_does_not_use_env_files
 
     print_summary


### PR DESCRIPTION
## Summary
- Pass `HOST_UID` and `HOST_GID` env vars to `docker create` so the devcontainer image's entrypoint can remap the `vscode` user to match the host on first start.
- Passed unconditionally — on macOS the host IDs (501:20) already match the image defaults and the entrypoint short-circuits; on Linux the remap fires once on first start.

## Test plan
- [x] `bash tests/test_cage.sh` — 83/83 pass (added 2 new tests)
- [ ] Verify on macOS: existing containers continue to work after recreation (`cage rm && cage start`)
- [ ] Verify on Linux: new container starts with files in project dir owned by host user

🤖 Generated with [Claude Code](https://claude.com/claude-code)