### PR TITLE
Print prominent banner when entering and exiting a cage

### DIFF
--- a/cage.sh
+++ b/cage.sh
@@ -19,6 +19,34 @@ fi
 die() { echo "error: $*" >&2; exit 1; }
 info() { echo "cage: $*" >&2; }
 
+cage_banner_enter() {
+    local name="$1"
+    local c="\033[1;36m" r="\033[0m"
+    local line="═══════════════════════════════════════════════════════════════"
+    printf '%b\n' "${c}${line}${r}" >&2
+    printf '%b\n' "${c}  ▶  ENTERING CAGE: ${name}${r}" >&2
+    printf '%b\n' "${c}  ▶  Type 'exit' or press Ctrl+D to return to host${r}" >&2
+    printf '%b\n' "${c}${line}${r}" >&2
+}
+
+cage_banner_exit() {
+    local name="$1"
+    local c="\033[1;33m" r="\033[0m"
+    local line="═══════════════════════════════════════════════════════════════"
+    printf '%b\n' "${c}${line}${r}" >&2
+    printf '%b\n' "${c}  ◀  EXITED CAGE: ${name} — back on host${r}" >&2
+    printf '%b\n' "${c}${line}${r}" >&2
+}
+
+drop_into_cage() {
+    local name="$1"; shift
+    cage_banner_enter "$name"
+    local rc=0
+    "$@" || rc=$?
+    cage_banner_exit "$name"
+    return $rc
+}
+
 container_name() {
     local abs_path="$1"
     local dirname
@@ -121,7 +149,7 @@ cmd_enter() {
                 info "A newer image is available. Run 'cage upgrade' to upgrade."
             fi
             info "Re-attaching to $name"
-            $DOCKER attach "$name"
+            drop_into_cage "$name" $DOCKER attach "$name"
             ;;
         stopped)
             if [ ${#port_flags[@]} -gt 0 ]; then
@@ -131,7 +159,7 @@ cmd_enter() {
                 info "A newer image is available. Run 'cage upgrade' to upgrade."
             fi
             info "Restarting $name"
-            $DOCKER start -ai "$name"
+            drop_into_cage "$name" $DOCKER start -ai "$name"
             ;;
         none)
             if [[ "$IMAGE" == */* ]]; then
@@ -187,9 +215,9 @@ cmd_enter() {
                 "$IMAGE" >/dev/null
 
             if seed_home "$name"; then
-                $DOCKER attach "$name"
+                drop_into_cage "$name" $DOCKER attach "$name"
             else
-                $DOCKER start -ai "$name"
+                drop_into_cage "$name" $DOCKER start -ai "$name"
             fi
             ;;
     esac
@@ -399,7 +427,7 @@ cmd_shell() {
 
     [ "$state" = "running" ] || die "Container $name is not running"
     info "Opening shell in $name"
-    $DOCKER exec -it "$name" zsh
+    drop_into_cage "$name" $DOCKER exec -it "$name" zsh
 }
 
 cmd_restart() {

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -1322,6 +1322,54 @@ test_start_no_env_files() {
     rm -rf "$project_dir"
 }
 
+test_start_new_container_prints_enter_and_exit_banners() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 1 ""
+    mock_docker_response "pull" 0 ""
+    mock_docker_response "create" 0 ""
+    mock_docker_response "start" 0 ""
+    local expected_name; expected_name="$(expected_container_name)"
+    local out; out="$(run_cage start 2>&1)"
+    assert_contains "$out" "ENTERING CAGE" "enter banner shown"
+    assert_contains "$out" "$expected_name" "enter banner contains container name"
+    assert_contains "$out" "EXITED CAGE" "exit banner shown"
+}
+
+test_start_reattach_prints_enter_and_exit_banners() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 0 "true"
+    mock_docker_response "image" 1 ""
+    mock_docker_response "attach" 0 ""
+    local out; out="$(run_cage start 2>&1)"
+    assert_contains "$out" "ENTERING CAGE" "enter banner shown on reattach"
+    assert_contains "$out" "EXITED CAGE" "exit banner shown on reattach"
+}
+
+test_start_restart_stopped_prints_enter_and_exit_banners() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 0 "false"
+    mock_docker_response "image" 1 ""
+    mock_docker_response "start" 0 ""
+    local out; out="$(run_cage start 2>&1)"
+    assert_contains "$out" "ENTERING CAGE" "enter banner shown on restart-stopped"
+    assert_contains "$out" "EXITED CAGE" "exit banner shown on restart-stopped"
+}
+
+test_shell_prints_enter_and_exit_banners() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 0 "true"
+    mock_docker_response "exec" 0 ""
+    local expected_name; expected_name="$(expected_container_name)"
+    local out; out="$(run_cage shell 2>&1)"
+    assert_contains "$out" "ENTERING CAGE" "enter banner shown for shell"
+    assert_contains "$out" "$expected_name" "enter banner contains container name"
+    assert_contains "$out" "EXITED CAGE" "exit banner shown for shell"
+}
+
 test_start_passes_host_uid_gid() {
     mock_reset
     mock_docker_response "info" 0 ""
@@ -1514,6 +1562,10 @@ main() {
     run_test test_start_project_env_file
     run_test test_start_both_env_files
     run_test test_start_no_env_files
+    run_test test_start_new_container_prints_enter_and_exit_banners
+    run_test test_start_reattach_prints_enter_and_exit_banners
+    run_test test_start_restart_stopped_prints_enter_and_exit_banners
+    run_test test_shell_prints_enter_and_exit_banners
     run_test test_start_passes_host_uid_gid
     run_test test_reattach_does_not_pass_host_uid_gid
     run_test test_reattach_does_not_use_env_files


### PR DESCRIPTION
## Summary
- Cage's interactive shell otherwise drops users into a prompt indistinguishable from their host shell. After exit, it's just as hard to tell you're back outside.
- Bold cyan entry banner and bold yellow exit banner make the boundary unmistakable.
- Applied to all four drop-in paths: new container create, restart-stopped, re-attach to running, and `cage shell`.

## Test plan
- [x] `bash tests/test_cage.sh` — 87/87 pass (added 4 tests covering each path)
- [ ] Verify visual rendering in a real terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "ENTERING CAGE" and "EXITED CAGE" banner messages to provide clear visual feedback when entering or exiting the container environment, displaying the container name

* **Tests**
  * Added new test cases to verify banner output displays correctly across container start, attach, restart, and shell operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacificsky/cage/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->