### PR TITLE
Add mount files and document the -v flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,10 +67,21 @@ cage injects environment variables from env files into containers at creation ti
 
 Both files use Docker env-file format: `KEY=VALUE` lines, `#` comments, blank lines. Per-project values override global for duplicate keys. Both are optional and silently skipped if absent. Only read at container creation; changes require `cage rm && cage start`.
 
+### Mount Files
+
+cage adds extra bind mounts declared in mount files at container creation time, as `-v` flags on `docker create`.
+
+- Global: `~/.config/cage/mounts` — applied to all cage containers
+- Per-project: `.cage.mounts` in the project directory — applied to that project's container only
+
+One `docker -v` spec per line. Blank lines and lines starting with `#` are ignored; leading `~/` expands to `$HOME`; a line with no `:` is expanded to `path:path` (same absolute path in the container). Everything else is passed to Docker verbatim, so `:ro` and named volumes work.
+
+Precedence when two mounts share a container-side target: command-line `-v` > `.cage.mounts` > global file. `build_mount_args` resolves this by walking the collected specs back to front and skipping targets already claimed. Unlike `-v` flags, mount files are re-read on every container creation, so they survive `restart` and `upgrade`.
+
 ### Testing
 
 - **Unit tests** (`tests/test_cage.sh`): Mock-based, no container runtime needed. Fast CI gate on every push.
-- **Integration tests** (`tests/test_integration.sh`): Run against a real container runtime (Docker or Podman). Uses `ubuntu:24.04` as a lightweight test image. The workflow fires on every pull request, but the test job only runs when `cage.sh`, `tests/**`, or the workflow file changed (otherwise skipped, and the gate passes as skipped); also runs on path-filtered pushes to main and manual dispatch. Refuse to run on macOS (they execute `obliterate`).
+- **Integration tests** (`tests/test_integration.sh`): Run against a real container runtime, in a CI matrix over **both** Docker and Podman — so avoid Docker-specific `inspect` templates in these tests. Uses `ubuntu:24.04` as a lightweight test image. The workflow fires on every pull request, but the test job only runs when `cage.sh`, `tests/**`, or the workflow file changed (otherwise skipped, and the gate passes as skipped); also runs on path-filtered pushes to main and manual dispatch. Refuse to run on macOS (they execute `obliterate`).
 
 ### Docker-Enabled Cages
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ cage start -p 3000:3000
 # Multiple ports
 cage start -p 3000:3000 -p 5432:5432
 
+# Mount an extra host directory into the container
+cage start -v ~/datasets:/datasets
+
 # Open a second shell while an agent is running
 cage shell
 
@@ -98,6 +101,22 @@ cage restart
 | SSH agent socket | `/run/host-services/ssh-auth.sock` (macOS) or `/tmp/ssh-agent.sock` (Linux) | SSH agent forwarding |
 
 On macOS, cage uses Docker Desktop's / Colima's SSH agent proxy. On Linux, it bind-mounts `$SSH_AUTH_SOCK` directly. `SSH_AUTH_SOCK` is set inside the container to match.
+
+#### Extra mounts
+
+`cage start` and `cage dstart` accept `-v`, with the same syntax as `docker run`:
+
+```bash
+# Mount a host directory at the same absolute path
+cage start -v ~/datasets:/Users/me/datasets
+
+# Read-only, and mixed with -p — both flags are repeatable
+cage start -v ~/models:/models:ro -p 3000:3000
+```
+
+Mounting a host path at the *same* absolute path is worth doing where you can. It's why the project directory is mounted that way: paths in error messages, stack traces, and tool output stay valid on both sides.
+
+`-v` only takes effect when a container is created. If one already exists, cage warns and ignores the flag — use `cage rm && cage start -v ...` to apply it. Note that `cage restart` and `cage upgrade` recreate the container *without* your original flags, so mounts you want to keep around belong in a [mount file](#mount-files) instead.
 
 ### Injected Environment Variables
 
@@ -154,6 +173,30 @@ DATABASE_URL=postgres://localhost/mydb
 ```
 
 Env files are read at container creation time. After changes: `cage rm && cage start`.
+
+### Mount Files
+
+Declare extra mounts once instead of passing `-v` on every `cage start` or `cage dstart`:
+
+| File | Scope | Description |
+|------|-------|-------------|
+| `~/.config/cage/mounts` | Global | Applied to all cage containers |
+| `.cage.mounts` | Per-project | Applied to the current project's container |
+
+One `docker -v` spec per line. Blank lines and lines starting with `#` are ignored, a leading `~/` expands to your home directory, and a line with no `:` is mounted at the same absolute path inside the container.
+
+```bash
+# ~/.config/cage/mounts
+~/datasets
+~/.aws:/home/vscode/.aws:ro
+
+# ~/src/my-project/.cage.mounts
+/Volumes/scratch:/scratch
+```
+
+When two mounts share the same container-side path, the more specific one wins: `-v` on the command line beats `.cage.mounts`, which beats the global file. That makes it possible to point a project at a different source for a path the global file already claims.
+
+Mount files are read at container creation time. After changes: `cage rm && cage start`. Unlike `-v` flags, they are re-read on every creation, so mounts declared this way survive `cage restart` and `cage upgrade`.
 
 ### Seed Directory
 

--- a/cage.sh
+++ b/cage.sh
@@ -202,6 +202,83 @@ check_colima_ssh_agent() {
     info "Fix: colima stop && colima start --ssh-agent"
 }
 
+# Read mount specs from a mounts file, one per line.  Blank lines and lines
+# starting with '#' are ignored.  A leading '~/' expands to $HOME.  A line with
+# no ':' is shorthand for mounting a host path at the same absolute path inside
+# the container, the way the project dir is mounted.  Anything else is handed to
+# docker verbatim, so ':ro' options and named volumes work as usual.
+read_mounts_file() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+
+    local spec
+    # No IFS= here, so read strips leading/trailing whitespace from each line.
+    while read -r spec || [ -n "$spec" ]; do
+        case "$spec" in
+            ""|"#"*) continue ;;
+            "~/"*)   spec="${HOME}/${spec#\~/}" ;;
+        esac
+        case "$spec" in
+            *:*) ;;
+            *)   spec="${spec}:${spec}" ;;
+        esac
+        printf '%s\n' "$spec"
+    done < "$file"
+}
+
+# The container-side target of a docker -v spec: the field after the first
+# colon, with any trailing options (':ro') removed.
+mount_target() {
+    local spec="$1"
+    local rest="${spec#*:}"
+    printf '%s\n' "${rest%%:*}"
+}
+
+# Emit '-v' and '<spec>' (one per line) for every extra mount declared in
+# ~/.config/cage/mounts and <project>/.cage.mounts.  When two mounts share a
+# container target the more specific one wins: a -v on the command line beats
+# the per-project file, which beats the global file.
+build_mount_args() {
+    local project_dir="$1"
+    shift
+
+    # Targets already claimed by command-line -v flags, delimited for lookup.
+    local claimed="|"
+    local target
+    while [ $# -gt 0 ]; do
+        if [ "$1" = "-v" ] && [ $# -ge 2 ]; then
+            target="$(mount_target "$2")"
+            claimed="${claimed}${target}|"
+            shift 2
+        else
+            shift
+        fi
+    done
+
+    local -a specs=()
+    local spec
+    while IFS= read -r spec; do
+        specs+=("$spec")
+    done < <(read_mounts_file "$HOME/.config/cage/mounts"
+             read_mounts_file "${project_dir}/.cage.mounts")
+
+    # Walk back to front so the last declaration of a target is the one kept,
+    # prepending each survivor so the emitted order still matches the files.
+    local -a out=()
+    local i
+    for (( i=${#specs[@]}-1; i>=0; i-- )); do
+        target="$(mount_target "${specs[$i]}")"
+        case "$claimed" in
+            *"|${target}|"*) continue ;;
+        esac
+        claimed="${claimed}${target}|"
+        out=(-v "${specs[$i]}" ${out[@]+"${out[@]}"})
+    done
+
+    [ ${#out[@]} -gt 0 ] || return 0
+    printf '%s\n' "${out[@]}"
+}
+
 # Copy seed files from ~/.config/cage/home/ into the container's /home/vscode/.
 # Uses cp -n (no-clobber) so existing files in the volume are never overwritten.
 # The container must be in "created" (stopped) state.  This function starts
@@ -226,7 +303,8 @@ seed_home() {
 cmd_enter() {
     local project_dir="$1"
     shift
-    local -a port_flags=("$@")
+    # Holds the -p and -v flags collected from the command line.
+    local -a cli_flags=("$@")
 
     local name
     name="$(container_name "$project_dir")"
@@ -237,8 +315,8 @@ cmd_enter() {
 
     case "$state" in
         running)
-            if [ ${#port_flags[@]} -gt 0 ]; then
-                info "Container already exists — ignoring -p flags. Use 'cage.sh rm' to recreate with new ports."
+            if [ ${#cli_flags[@]} -gt 0 ]; then
+                info "Container already exists — ignoring -p/-v flags. Use 'cage.sh rm' to recreate with new ports and mounts."
             fi
             if image_newer_available "$name"; then
                 info "A newer image is available. Run 'cage upgrade' to upgrade."
@@ -247,8 +325,8 @@ cmd_enter() {
             drop_into_cage "$name" $DOCKER attach "$name"
             ;;
         stopped)
-            if [ ${#port_flags[@]} -gt 0 ]; then
-                info "Container already exists — ignoring -p flags. Use 'cage.sh rm' to recreate with new ports."
+            if [ ${#cli_flags[@]} -gt 0 ]; then
+                info "Container already exists — ignoring -p/-v flags. Use 'cage.sh rm' to recreate with new ports and mounts."
             fi
             if image_newer_available "$name"; then
                 info "A newer image is available. Run 'cage upgrade' to upgrade."
@@ -267,6 +345,13 @@ cmd_enter() {
                 -v "${project_dir}:${project_dir}"
                 -v "${HOME_VOL}:/home/vscode"
             )
+
+            # Extra mounts declared in ~/.config/cage/mounts and .cage.mounts.
+            local -a extra_mount_args=()
+            local mount_arg
+            while IFS= read -r mount_arg; do
+                extra_mount_args+=("$mount_arg")
+            done < <(build_mount_args "$project_dir" ${cli_flags[@]+"${cli_flags[@]}"})
 
             # Forward the host SSH agent so git/ssh work inside the container.
             local -a ssh_agent_args=()
@@ -313,8 +398,9 @@ cmd_enter() {
                 --name "$name" \
                 --hostname "$name" \
                 --workdir "$project_dir" \
-                ${port_flags[@]+"${port_flags[@]}"} \
+                ${cli_flags[@]+"${cli_flags[@]}"} \
                 "${mount_args[@]}" \
+                ${extra_mount_args[@]+"${extra_mount_args[@]}"} \
                 ${ssh_agent_args[@]+"${ssh_agent_args[@]}"} \
                 ${env_file_args[@]+"${env_file_args[@]}"} \
                 ${docker_args[@]+"${docker_args[@]}"} \
@@ -758,7 +844,15 @@ Environment files:
   .cage.env               Per-project env vars (optional, overrides global)
                           Format: KEY=VALUE lines, # comments, blank lines
 
-Port (-p), volume (-v) flags and env files only apply when creating a new container.
+Mount files:
+  ~/.config/cage/mounts   Global extra mounts for all containers (optional)
+  .cage.mounts            Per-project extra mounts (optional, overrides global)
+                          Format: one docker -v spec per line.  Blank lines
+                          and lines starting with # are ignored, '~/' expands
+                          to $HOME, and a line with no ':' is mounted at the
+                          same absolute path inside the container.
+
+Port (-p), volume (-v) flags and config files only apply when creating a new container.
 To change: cage.sh rm && cage.sh start -p 3000:3000 -v /data:/data
 EOF
 }

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -606,7 +606,7 @@ test_start_ignores_port_flags_when_running() {
     mock_docker_response "image" 1 ""
     mock_docker_response "attach" 0 ""
     local out; out="$(run_cage start -p 3000:3000 2>&1)"
-    assert_contains "$out" "ignoring -p flags" "port-ignored warning"
+    assert_contains "$out" "ignoring -p/-v flags" "port-ignored warning"
 }
 
 test_start_ignores_port_flags_when_stopped() {
@@ -616,7 +616,7 @@ test_start_ignores_port_flags_when_stopped() {
     mock_docker_response "image" 1 ""
     mock_docker_response "start" 0 ""
     local out; out="$(run_cage start -p 3000:3000 2>&1)"
-    assert_contains "$out" "ignoring -p flags" "port-ignored warning"
+    assert_contains "$out" "ignoring -p/-v flags" "port-ignored warning"
 }
 
 test_start_passes_port_to_docker_create() {
@@ -2092,6 +2092,203 @@ test_start_reattaches_via_routing() {
 }
 
 # ================================================================
+# Tests: mount file support
+# ================================================================
+
+# Shared setup for the mount-file tests: fresh mocks for a container that
+# does not exist yet, plus an empty project dir.  Echoes the project dir.
+setup_mount_test() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 1 ""
+    mock_docker_response "pull" 0 ""
+    mock_docker_response "create" 0 ""
+    mock_docker_response "start" 0 ""
+
+    rm -f "$HOME/.config/cage/mounts"
+    mkdir -p "$HOME/.config/cage"
+    mktemp -d
+}
+
+test_start_global_mounts_file() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/data:/data" > "$HOME/.config/cage/mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    assert_contains "$(mock_calls)" "-v /data:/data" "global mount in docker create"
+
+    rm -f "$HOME/.config/cage/mounts"
+    rm -rf "$project_dir"
+}
+
+test_start_project_mounts_file() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/models:/models:ro" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    assert_contains "$(mock_calls)" "-v /models:/models:ro" "project mount in docker create"
+
+    rm -rf "$project_dir"
+}
+
+test_start_both_mounts_files() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/data:/data" > "$HOME/.config/cage/mounts"
+    echo "/models:/models" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /data:/data" "global mount present"
+    assert_contains "$calls" "-v /models:/models" "project mount present"
+
+    rm -f "$HOME/.config/cage/mounts"
+    rm -rf "$project_dir"
+}
+
+test_start_no_mounts_files() {
+    local project_dir; project_dir="$(setup_mount_test)"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    # Only cage's own two mounts (project dir and shared home) should appear.
+    assert_eq "2" "$(grep -o -- '-v ' <<<"$calls" | wc -l | tr -d ' ')" \
+        "no extra -v flags when mount files absent"
+
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_ignores_comments_and_blanks() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    printf '# a comment\n\n  \n  /data:/data  \n' > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /data:/data" "spec is read despite surrounding noise"
+    assert_not_contains "$calls" "a comment" "comment not passed to docker"
+    assert_eq "3" "$(grep -o -- '-v ' <<<"$calls" | wc -l | tr -d ' ')" \
+        "blank lines produce no mounts"
+
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_expands_tilde() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "~/notes:/notes" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    assert_contains "$(mock_calls)" "-v ${HOME}/notes:/notes" "leading ~/ expanded to \$HOME"
+
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_same_path_shorthand() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    printf '/srv/data\n~/notes\n' > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /srv/data:/srv/data" "colon-less line mounted at same path"
+    assert_contains "$calls" "-v ${HOME}/notes:${HOME}/notes" "shorthand expands ~ on both sides"
+
+    rm -rf "$project_dir"
+}
+
+test_start_project_mounts_override_global() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/global/data:/data" > "$HOME/.config/cage/mounts"
+    echo "/project/data:/data" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /project/data:/data" "project mount wins for shared target"
+    assert_not_contains "$calls" "/global/data" "global mount dropped for shared target"
+
+    rm -f "$HOME/.config/cage/mounts"
+    rm -rf "$project_dir"
+}
+
+test_start_cli_volume_overrides_mounts_files() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/global/data:/data" > "$HOME/.config/cage/mounts"
+    echo "/project/data:/data" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start -v /cli/data:/data >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /cli/data:/data" "command-line mount wins for shared target"
+    assert_not_contains "$calls" "/project/data" "project mount dropped for shared target"
+    assert_not_contains "$calls" "/global/data" "global mount dropped for shared target"
+
+    rm -f "$HOME/.config/cage/mounts"
+    rm -rf "$project_dir"
+}
+
+test_start_cli_volume_keeps_unrelated_file_mounts() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/models:/models" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start -v /cli/data:/data >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /cli/data:/data" "command-line mount present"
+    assert_contains "$calls" "-v /models:/models" "unrelated file mount kept"
+
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_ro_option_target_matching() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/global/data:/data:ro" > "$HOME/.config/cage/mounts"
+    echo "/project/data:/data" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /project/data:/data" "project mount wins"
+    assert_not_contains "$calls" "/global/data" "target matched despite :ro option on global"
+
+    rm -f "$HOME/.config/cage/mounts"
+    rm -rf "$project_dir"
+}
+
+test_reattach_does_not_use_mounts_files() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 0 "true"
+    mock_docker_response "image" 1 ""
+    mock_docker_response "attach" 0 ""
+
+    mkdir -p "$HOME/.config/cage"
+    echo "/data:/data" > "$HOME/.config/cage/mounts"
+    local project_dir; project_dir="$(mktemp -d)"
+    echo "/models:/models" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    assert_not_contains "$(mock_calls)" "-v " "no mounts on reattach"
+
+    rm -f "$HOME/.config/cage/mounts"
+    rm -rf "$project_dir"
+}
+
+test_restart_reapplies_mounts_files() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    # First inspect: container exists.  Second (from cmd_enter): gone after rm.
+    mock_docker_response_n "inspect" 1 0 "true"
+    mock_docker_response "inspect" 1 ""
+    mock_docker_response "pull" 0 ""
+    mock_docker_response "rm" 0 ""
+    mock_docker_response "create" 0 ""
+    mock_docker_response "start" 0 ""
+
+    local project_dir; project_dir="$(mktemp -d)"
+    echo "/models:/models" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage restart >/dev/null 2>&1 || true)
+    assert_contains "$(mock_calls)" "-v /models:/models" "mount file reapplied on restart"
+
+    rm -rf "$project_dir"
+}
+
+
+# ================================================================
 # Run all tests
 # ================================================================
 
@@ -2291,6 +2488,22 @@ main() {
     run_test test_no_routing_without_cage_vm_socket
     run_test test_no_routing_on_linux
     run_test test_start_reattaches_via_routing
+
+    echo ""
+    echo "--- mount file support ---"
+    run_test test_start_global_mounts_file
+    run_test test_start_project_mounts_file
+    run_test test_start_both_mounts_files
+    run_test test_start_no_mounts_files
+    run_test test_start_mounts_file_ignores_comments_and_blanks
+    run_test test_start_mounts_file_expands_tilde
+    run_test test_start_mounts_file_same_path_shorthand
+    run_test test_start_project_mounts_override_global
+    run_test test_start_cli_volume_overrides_mounts_files
+    run_test test_start_cli_volume_keeps_unrelated_file_mounts
+    run_test test_start_mounts_file_ro_option_target_matching
+    run_test test_reattach_does_not_use_mounts_files
+    run_test test_restart_reapplies_mounts_files
 
     print_summary
 }

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -2248,6 +2248,40 @@ test_start_mounts_file_ro_option_target_matching() {
     rm -rf "$project_dir"
 }
 
+test_dstart_applies_mounts_file() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    mock_uname Linux
+    mock_stat_gid 999
+    echo "/models:/models" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage dstart >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    # dstart delegates to cmd_enter, so mount files apply there too — this
+    # pins that delegation, which is the only reason it works.
+    assert_contains "$calls" "-v /models:/models" "mount file applied by dstart"
+    assert_contains "$calls" "cage.docker=host" "still a docker-enabled cage"
+
+    unmock_stat
+    unmock_uname
+    rm -rf "$project_dir"
+}
+
+test_dstart_cli_volume_overrides_mounts_file() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    mock_uname Linux
+    mock_stat_gid 999
+    echo "/file/data:/data" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage dstart -v /cli/data:/data >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /cli/data:/data" "command-line mount wins under dstart"
+    assert_not_contains "$calls" "/file/data" "file mount dropped for shared target"
+
+    unmock_stat
+    unmock_uname
+    rm -rf "$project_dir"
+}
+
 test_reattach_does_not_use_mounts_files() {
     mock_reset
     mock_docker_response "info" 0 ""
@@ -2502,6 +2536,8 @@ main() {
     run_test test_start_cli_volume_overrides_mounts_files
     run_test test_start_cli_volume_keeps_unrelated_file_mounts
     run_test test_start_mounts_file_ro_option_target_matching
+    run_test test_dstart_applies_mounts_file
+    run_test test_dstart_cli_volume_overrides_mounts_file
     run_test test_reattach_does_not_use_mounts_files
     run_test test_restart_reapplies_mounts_files
 

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -378,6 +378,120 @@ test_env_file_override() {
     rm -f "$HOME/.config/cage/env" "$pdir/.cage.env"
 }
 
+test_mounts_file_project() {
+    local pdir; pdir="$(make_project_dir)"
+    local name; name="$(container_name_for "$pdir")"
+    local host_dir; host_dir="$(make_project_dir)"
+
+    echo "from host" > "$host_dir/data.txt"
+    echo "${host_dir}:/mnt/extra" > "$pdir/.cage.mounts"
+
+    start_cage_in "$pdir" start
+
+    $DOCKER start "$name" >/dev/null 2>&1 || true
+    local content
+    content="$($DOCKER exec "$name" cat /mnt/extra/data.txt 2>/dev/null)" || true
+    assert_eq "from host" "$content" "project mount visible in container"
+
+    cleanup_container "$name"
+    rm -f "$pdir/.cage.mounts"
+}
+
+test_mounts_file_global() {
+    local pdir; pdir="$(make_project_dir)"
+    local name; name="$(container_name_for "$pdir")"
+    local host_dir; host_dir="$(make_project_dir)"
+
+    echo "from global" > "$host_dir/data.txt"
+    mkdir -p "$HOME/.config/cage"
+    echo "${host_dir}:/mnt/global" > "$HOME/.config/cage/mounts"
+
+    start_cage_in "$pdir" start
+
+    $DOCKER start "$name" >/dev/null 2>&1 || true
+    local content
+    content="$($DOCKER exec "$name" cat /mnt/global/data.txt 2>/dev/null)" || true
+    assert_eq "from global" "$content" "global mount visible in container"
+
+    cleanup_container "$name"
+    rm -f "$HOME/.config/cage/mounts"
+}
+
+test_mounts_file_same_path_shorthand() {
+    local pdir; pdir="$(make_project_dir)"
+    local name; name="$(container_name_for "$pdir")"
+    local host_dir; host_dir="$(make_project_dir)"
+
+    echo "same path" > "$host_dir/data.txt"
+    echo "$host_dir" > "$pdir/.cage.mounts"
+
+    start_cage_in "$pdir" start
+
+    $DOCKER start "$name" >/dev/null 2>&1 || true
+    local content
+    content="$($DOCKER exec "$name" cat "$host_dir/data.txt" 2>/dev/null)" || true
+    assert_eq "same path" "$content" "colon-less spec mounted at the same absolute path"
+
+    cleanup_container "$name"
+    rm -f "$pdir/.cage.mounts"
+}
+
+test_mounts_file_override() {
+    local pdir; pdir="$(make_project_dir)"
+    local name; name="$(container_name_for "$pdir")"
+    local global_dir; global_dir="$(make_project_dir)"
+    local project_dir; project_dir="$(make_project_dir)"
+
+    echo "global" > "$global_dir/data.txt"
+    echo "project" > "$project_dir/data.txt"
+    mkdir -p "$HOME/.config/cage"
+    echo "${global_dir}:/mnt/shared" > "$HOME/.config/cage/mounts"
+    echo "${project_dir}:/mnt/shared" > "$pdir/.cage.mounts"
+
+    start_cage_in "$pdir" start
+
+    $DOCKER start "$name" >/dev/null 2>&1 || true
+    local content
+    content="$($DOCKER exec "$name" cat /mnt/shared/data.txt 2>/dev/null)" || true
+    assert_eq "project" "$content" "project mount overrides global for same target"
+
+    cleanup_container "$name"
+    rm -f "$HOME/.config/cage/mounts" "$pdir/.cage.mounts"
+}
+
+test_mounts_file_readonly() {
+    local pdir; pdir="$(make_project_dir)"
+    local name; name="$(container_name_for "$pdir")"
+    local host_dir; host_dir="$(make_project_dir)"
+
+    echo "locked" > "$host_dir/data.txt"
+    # The same host dir mounted twice — once writable, once read-only — so
+    # ownership and permissions are identical either way.  A write that
+    # succeeds on /mnt/rw but fails on /mnt/ro isolates ':ro' as the cause;
+    # checking only the failure could pass for unrelated reasons.  Two specs
+    # in one file also covers multi-line mount files.
+    printf '%s:/mnt/rw\n%s:/mnt/ro:ro\n' "$host_dir" "$host_dir" > "$pdir/.cage.mounts"
+
+    start_cage_in "$pdir" start
+
+    $DOCKER start "$name" >/dev/null 2>&1 || true
+    local rw_rc=0 ro_rc=0
+    $DOCKER exec "$name" sh -c 'echo probe > /mnt/rw/probe.txt' >/dev/null 2>&1 || rw_rc=$?
+    $DOCKER exec "$name" sh -c 'echo probe > /mnt/ro/probe.txt' >/dev/null 2>&1 || ro_rc=$?
+
+    assert_eq "0" "$rw_rc" "plain mount accepts writes"
+    if [ "$ro_rc" -eq 0 ]; then
+        fail ":ro mount should reject writes"
+    fi
+
+    local content
+    content="$($DOCKER exec "$name" cat /mnt/ro/data.txt 2>/dev/null)" || true
+    assert_eq "locked" "$content" ":ro mount is still readable"
+
+    cleanup_container "$name"
+    rm -f "$pdir/.cage.mounts"
+}
+
 test_list_shows_container() {
     local pdir; pdir="$(make_project_dir)"
     local name; name="$(container_name_for "$pdir")"
@@ -569,6 +683,14 @@ main() {
     run_test test_env_file_project
     run_test test_env_file_global
     run_test test_env_file_override
+
+    echo ""
+    echo "--- mount file ---"
+    run_test test_mounts_file_project
+    run_test test_mounts_file_global
+    run_test test_mounts_file_same_path_shorthand
+    run_test test_mounts_file_override
+    run_test test_mounts_file_readonly
 
     echo ""
     echo "--- listing and cleanup ---"


### PR DESCRIPTION
## Summary

Two related changes to how extra host directories get into a cage.

**1. Document `-v` in the README.** `cage start` has accepted `-v` since ports were added, but it only appeared in `cage.sh help` — the README never mentioned it. It's now covered under *How It Works → Mounts*, along with the two behaviours that surprise people: an existing container ignores the flag, and `restart`/`upgrade` recreate the container *without* it.

**2. Add mount files**, the `-v` equivalent of the existing env files:

| File | Scope |
|------|-------|
| `~/.config/cage/mounts` | All cage containers |
| `.cage.mounts` | The current project's container |

```bash
# ~/.config/cage/mounts
~/datasets                        # → /Users/me/datasets:/Users/me/datasets
~/.aws:/home/vscode/.aws:ro
```

One docker `-v` spec per line. Blank lines and lines starting with `#` are ignored, a leading `~/` expands to `$HOME`, and a line with no `:` is mounted at the same absolute path inside the container — the way the project dir already is. Everything else passes through verbatim, so `:ro` and named volumes work.

Both apply to `cage dstart` as well: it shares the `start` flag parser and delegates to `cmd_enter`, where the single `docker create` lives.

## Design notes

**Precedence by container-side target:** command-line `-v` > `.cage.mounts` > global file. Without this, a project needing a different source for a path the global file already claims would hit a hard `Duplicate mount point` error from the runtime, with no workaround short of editing the global file. Duplicate identical specs collapse for the same reason.

**Mount files survive `restart` and `upgrade`.** They're re-read from disk on every container creation rather than passed as flags, which is the fix for gotcha #1 above. `-v` flags are still dropped by those commands, and the README now says so explicitly.

Comments are line-start only, not inline, matching the env-file convention — a trailing `# comment` would otherwise become part of the path.

## Testing

13 unit tests covering precedence, `~` expansion, same-path shorthand, comments/blank lines, `:ro` target matching, and non-application on re-attach. Suite is green at 136/136. A mutation check (stubbing out the mount-arg builder) confirmed 13 assertions fail without the feature, so the tests aren't passing vacuously.

5 integration tests (project, global, shorthand, override, `:ro`), **confirmed green on both runtimes in CI** — docker 24/24, podman 18/18. The `:ro` test mounts the same host dir twice, plain and read-only, and asserts a write succeeds on one and fails on the other; ownership is identical across both, so `:ro` is the only variable. It deliberately avoids `inspect` templates over `.Mounts`, since this suite runs against podman as well as docker.

## Incidental

- The stale `ignoring -p flags` warning now reads `-p/-v`; it has always covered both. Two test assertions updated to match.
- CLAUDE.md's integration-test entry now records that CI runs a matrix over *both* docker and podman, with a note to keep that suite runtime-agnostic.
- No `VERSION` bump; this repo does those in separate commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmBvXnMCMwqzCgHYrRcozz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring extra container directory mounts through global and project-specific mount files.
  * Added repeatable `-v` options for ad hoc mounts, including read-only mounts.
  * Added mount precedence rules, shorthand syntax, tilde expansion, and persistence when recreating containers.
  * Updated command help and documentation with mount configuration and behavior details.

* **Bug Fixes**
  * Improved warnings when port and volume options are ignored for existing containers.

* **Tests**
  * Added coverage for mount files, overrides, read-only mounts, and container lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->