### PR TITLE
Support 'path::opts' for a same-path mount with options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,13 @@ cage adds extra bind mounts declared in mount files at container creation time, 
 - Global: `~/.config/cage/mounts` — applied to all cage containers
 - Per-project: `.cage.mounts` in the project directory — applied to that project's container only
 
-One `docker -v` spec per line. Blank lines and lines starting with `#` are ignored; leading `~/` expands to `$HOME`; a line with no `:` is expanded to `path:path` (same absolute path in the container). Everything else is passed to Docker verbatim, so `:ro` and named volumes work.
+One `docker -v` spec per line. Blank lines and lines starting with `#` are ignored; leading `~/` expands to `$HOME` (start of the spec only — the container home is `/home/vscode`, so expanding a container-side `~` would be a lie). Forms handled in `read_mounts_file`:
+
+- `path` → `path:path` (same absolute path in the container)
+- `path::opts` → `path:path:opts` — empty middle field means same path *with* options. Docker rejects an empty container path, so this spelling is free to take on a meaning; it avoids having to maintain a list of known option keywords to disambiguate `path:ro`.
+- anything else → passed to Docker verbatim, so named volumes work.
+
+`cmd_enter` rejects a non-absolute container target with a message pointing at the `::` form. That check lives in `cmd_enter`, not `read_mounts_file`, because the latter runs inside a process substitution where `die` could not halt the run.
 
 Precedence when two mounts share a container-side target: command-line `-v` > `.cage.mounts` > global file. `build_mount_args` resolves this by walking the collected specs back to front and skipping targets already claimed. Unlike `-v` flags, mount files are re-read on every container creation, so they survive `restart` and `upgrade`.
 

--- a/README.md
+++ b/README.md
@@ -183,16 +183,26 @@ Declare extra mounts once instead of passing `-v` on every `cage start` or `cage
 | `~/.config/cage/mounts` | Global | Applied to all cage containers |
 | `.cage.mounts` | Per-project | Applied to the current project's container |
 
-One `docker -v` spec per line. Blank lines and lines starting with `#` are ignored, a leading `~/` expands to your home directory, and a line with no `:` is mounted at the same absolute path inside the container.
+One `docker -v` spec per line. Blank lines and lines starting with `#` are ignored, and a leading `~/` expands to your home directory.
 
 ```bash
 # ~/.config/cage/mounts
-~/datasets
-~/.aws:/home/vscode/.aws:ro
+~/datasets                       # same absolute path inside the container
+~/models::ro                     # same path, read-only
+~/.aws:/home/vscode/.aws:ro      # explicit host:container:options
+cache-vol:/home/vscode/.cache    # named volume
 
 # ~/src/my-project/.cage.mounts
 /Volumes/scratch:/scratch
 ```
+
+| Form | Meaning |
+|------|---------|
+| `path` | Mounted at the same absolute path inside the container |
+| `path::options` | Same path, with Docker options (`ro`, `ro,z`, …) |
+| `host:container[:options]` | Passed to Docker verbatim |
+
+The empty middle field in `path::ro` is what asks for "same path on both sides" while still taking options — Docker rejects an empty container path, so the spelling is unambiguous. Note that `~` expands *only* at the start of a spec: `~/data:~/data:ro` does **not** work, because the container's home is `/home/vscode`, not yours. cage rejects a non-absolute container path with a message pointing at the `::` form rather than letting Docker fail obscurely.
 
 When two mounts share the same container-side path, the more specific one wins: `-v` on the command line beats `.cage.mounts`, which beats the global file. That makes it possible to point a project at a different source for a path the global file already claims.
 

--- a/cage.sh
+++ b/cage.sh
@@ -211,7 +211,7 @@ read_mounts_file() {
     local file="$1"
     [ -f "$file" ] || return 0
 
-    local spec
+    local spec host opts
     # No IFS= here, so read strips leading/trailing whitespace from each line.
     while read -r spec || [ -n "$spec" ]; do
         case "$spec" in
@@ -219,8 +219,26 @@ read_mounts_file() {
             "~/"*)   spec="${HOME}/${spec#\~/}" ;;
         esac
         case "$spec" in
-            *:*) ;;
-            *)   spec="${spec}:${spec}" ;;
+            *::*)
+                # 'path::opts' — an empty middle field means the same absolute
+                # path inside the container, keeping the options.  Docker
+                # rejects an empty container path, so this spelling is free to
+                # take on a meaning.  Skipped if the host path itself has a
+                # colon, which is not a leading '::' at all.
+                host="${spec%%::*}"
+                opts="${spec#*::}"
+                case "$host" in
+                    *:*) ;;
+                    *)   if [ -n "$opts" ]; then
+                             spec="${host}:${host}:${opts}"
+                         else
+                             spec="${host}:${host}"
+                         fi
+                         ;;
+                esac
+                ;;
+            *:*) ;;                          # host:container[:opts] — verbatim
+            *)   spec="${spec}:${spec}" ;;   # bare path — same path, no options
         esac
         printf '%s\n' "$spec"
     done < "$file"
@@ -347,9 +365,21 @@ cmd_enter() {
             )
 
             # Extra mounts declared in ~/.config/cage/mounts and .cage.mounts.
+            # Validated here rather than in read_mounts_file, which runs in a
+            # process substitution where die() could not stop the run.
             local -a extra_mount_args=()
-            local mount_arg
+            local mount_arg prev_arg="" target
             while IFS= read -r mount_arg; do
+                if [ "$prev_arg" = "-v" ]; then
+                    target="$(mount_target "$mount_arg")"
+                    case "$target" in
+                        /*) ;;
+                        *)  die "invalid mount '${mount_arg}': container path '${target}' is not absolute.
+       For the same path on both sides with options, use 'host::options' (e.g. '~/data::ro').
+       '~' expands only at the start of a spec — the container home is /home/vscode." ;;
+                    esac
+                fi
+                prev_arg="$mount_arg"
                 extra_mount_args+=("$mount_arg")
             done < <(build_mount_args "$project_dir" ${cli_flags[@]+"${cli_flags[@]}"})
 
@@ -848,9 +878,11 @@ Mount files:
   ~/.config/cage/mounts   Global extra mounts for all containers (optional)
   .cage.mounts            Per-project extra mounts (optional, overrides global)
                           Format: one docker -v spec per line.  Blank lines
-                          and lines starting with # are ignored, '~/' expands
-                          to $HOME, and a line with no ':' is mounted at the
-                          same absolute path inside the container.
+                          and lines starting with # are ignored and a leading
+                          '~/' expands to $HOME.  Forms:
+                            path                     same path in container
+                            path::opts               same path, with options
+                            host:container[:opts]    passed to docker as-is
 
 Port (-p), volume (-v) flags and config files only apply when creating a new container.
 To change: cage.sh rm && cage.sh start -p 3000:3000 -v /data:/data

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -2193,6 +2193,81 @@ test_start_mounts_file_same_path_shorthand() {
     rm -rf "$project_dir"
 }
 
+test_start_mounts_file_same_path_with_options() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    printf '/srv/data::ro\n~/notes::ro,z\n' > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /srv/data:/srv/data:ro" "'path::ro' means same path, read-only"
+    assert_contains "$calls" "-v ${HOME}/notes:${HOME}/notes:ro,z" "options list preserved verbatim"
+
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_same_path_empty_options() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/srv/data::" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    assert_contains "$(mock_calls)" "-v /srv/data:/srv/data " "trailing '::' with no options is plain same-path"
+
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_explicit_target_unaffected() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    printf '/a:/b:ro\ncache-vol:/home/vscode/.cache\n' > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    assert_contains "$calls" "-v /a:/b:ro" "explicit host:container:opts passed through"
+    assert_contains "$calls" "-v cache-vol:/home/vscode/.cache" "named volume passed through"
+
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_same_path_target_participates_in_precedence() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/data::ro" > "$HOME/.config/cage/mounts"
+    echo "/project/data:/data" > "$project_dir/.cage.mounts"
+
+    (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
+    local calls; calls="$(mock_calls)"
+    # The '::' form's target is /data, so the project entry must still win.
+    assert_contains "$calls" "-v /project/data:/data" "project mount wins over '::' global"
+    assert_not_contains "$calls" "/data:/data:ro" "global '::' mount dropped for shared target"
+
+    rm -f "$HOME/.config/cage/mounts"
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_rejects_relative_container_path() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/srv/notes:ro" > "$project_dir/.cage.mounts"
+
+    local out rc=0
+    out="$(cd "$project_dir" && run_cage start 2>&1)" || rc=$?
+    assert_eq "1" "$rc" "exits non-zero on a relative container path"
+    assert_contains "$out" "container path 'ro' is not absolute" "names the offending path"
+    assert_contains "$out" "host::options" "suggests the '::' spelling"
+    assert_not_contains "$(mock_calls)" "create" "container is not created"
+
+    rm -rf "$project_dir"
+}
+
+test_start_mounts_file_rejects_tilde_container_path() {
+    local project_dir; project_dir="$(setup_mount_test)"
+    echo "/srv/x:~/x:ro" > "$project_dir/.cage.mounts"
+
+    local out rc=0
+    out="$(cd "$project_dir" && run_cage start 2>&1)" || rc=$?
+    assert_eq "1" "$rc" "exits non-zero on a container-side ~"
+    assert_contains "$out" "container path '~/x' is not absolute" "names the unexpanded ~ path"
+
+    rm -rf "$project_dir"
+}
+
 test_start_project_mounts_override_global() {
     local project_dir; project_dir="$(setup_mount_test)"
     echo "/global/data:/data" > "$HOME/.config/cage/mounts"
@@ -2532,6 +2607,12 @@ main() {
     run_test test_start_mounts_file_ignores_comments_and_blanks
     run_test test_start_mounts_file_expands_tilde
     run_test test_start_mounts_file_same_path_shorthand
+    run_test test_start_mounts_file_same_path_with_options
+    run_test test_start_mounts_file_same_path_empty_options
+    run_test test_start_mounts_file_explicit_target_unaffected
+    run_test test_start_mounts_file_same_path_target_participates_in_precedence
+    run_test test_start_mounts_file_rejects_relative_container_path
+    run_test test_start_mounts_file_rejects_tilde_container_path
     run_test test_start_project_mounts_override_global
     run_test test_start_cli_volume_overrides_mounts_files
     run_test test_start_cli_volume_keeps_unrelated_file_mounts

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -436,6 +436,37 @@ test_mounts_file_same_path_shorthand() {
     rm -f "$pdir/.cage.mounts"
 }
 
+test_mounts_file_same_path_with_options() {
+    local pdir; pdir="$(make_project_dir)"
+    local name; name="$(container_name_for "$pdir")"
+    local rw_dir; rw_dir="$(make_project_dir)"
+    local ro_dir; ro_dir="$(make_project_dir)"
+
+    echo "locked" > "$ro_dir/data.txt"
+    # '::' is same-path with no options; '::ro' is same-path, read-only.  The
+    # writable one is the control: it proves a failed write on the other is
+    # caused by ':ro' and not by ownership.
+    printf '%s::\n%s::ro\n' "$rw_dir" "$ro_dir" > "$pdir/.cage.mounts"
+
+    start_cage_in "$pdir" start
+    $DOCKER start "$name" >/dev/null 2>&1 || true
+
+    local content
+    content="$($DOCKER exec "$name" cat "$ro_dir/data.txt" 2>/dev/null)" || true
+    assert_eq "locked" "$content" "'::ro' mounts at the same absolute path"
+
+    local rw_rc=0 ro_rc=0
+    $DOCKER exec "$name" sh -c "echo probe > $rw_dir/probe.txt" >/dev/null 2>&1 || rw_rc=$?
+    $DOCKER exec "$name" sh -c "echo probe > $ro_dir/probe.txt" >/dev/null 2>&1 || ro_rc=$?
+    assert_eq "0" "$rw_rc" "'::' mount accepts writes"
+    if [ "$ro_rc" -eq 0 ]; then
+        fail "'::ro' mount should reject writes"
+    fi
+
+    cleanup_container "$name"
+    rm -f "$pdir/.cage.mounts"
+}
+
 test_mounts_file_override() {
     local pdir; pdir="$(make_project_dir)"
     local name; name="$(container_name_for "$pdir")"
@@ -689,6 +720,7 @@ main() {
     run_test test_mounts_file_project
     run_test test_mounts_file_global
     run_test test_mounts_file_same_path_shorthand
+    run_test test_mounts_file_same_path_with_options
     run_test test_mounts_file_override
     run_test test_mounts_file_readonly
 


### PR DESCRIPTION
## The gap

`.cage.mounts` supported a same-path shorthand, but only as a single field — so there was no way to say *"same absolute path, read-only"* without hardcoding your home directory:

```bash
~/datasets                              # same path, but read-write only
~/datasets:~/datasets:ro                # broken (see below)
/Users/me/datasets:/Users/me/datasets:ro  # works, but not portable
```

The middle one fails because `~` expands only at the *start* of a spec — deliberately, since the container's home is `/home/vscode`, not yours — so Docker sees a container path of `~/datasets` and rejects it as non-absolute.

## The fix

Give the empty middle field a meaning:

| Form | Expands to |
|------|-----------|
| `path` | `path:path` |
| `path::opts` | `path:path:opts` |
| `host:container[:opts]` | verbatim |

```bash
~/models::ro
/srv/data::ro,z
```

This is strictly additive: Docker rejects an empty container path, so no spec that works today changes meaning.

**Why `::` rather than reading `path:ro` as shorthand-plus-options:** that alternative has to recognise `ro`/`rw`/`z`/`Z`/`cached`/`delegated`/`nocopy`/`rshared`/… as option keywords, which means maintaining a list in sync with Docker and inferring intent from what a token happens to look like. `::` needs no list, is explicit at the call site, and works with any option Docker adds later.

## Better error instead of a confusing one

A non-absolute container path is now rejected up front, naming the offending path and pointing at the `::` form:

```
error: invalid mount '/home/me/notes:ro': container path 'ro' is not absolute.
       For the same path on both sides with options, use 'host::options' (e.g. '~/data::ro').
       '~' expands only at the start of a spec — the container home is /home/vscode.
```

The check lives in `cmd_enter`, not `read_mounts_file` — the latter runs inside a process substitution where `die` could not halt the run.

## Testing

6 new unit tests (options preserved, empty `::`, explicit targets and named volumes unaffected, `::` targets participating in precedence, and both rejection paths). Suite green at 144/144. Mutation-checked: disabling the `::` branch fails 4 assertions.

1 new integration test mounting two dirs same-path — one `::` and one `::ro` — asserting a write succeeds on the first and fails on the second. The writable one is the control, so the read-only assertion can't pass for ownership reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmBvXnMCMwqzCgHYrRcozz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mount files now support same-path mounts with Docker options, including `::` and `::ro` forms.
  - Added support for explicit host/container paths and named volumes.
  - Mount options now preserve expected read-only and writable behavior.

- **Bug Fixes**
  - Invalid relative or tilde-based container paths are rejected with guidance.

- **Documentation**
  - Expanded mount syntax reference, examples, option behavior, and validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->