### PR TITLE
Bump to 0.10.0 and verify the tag matches VERSION on release

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -12,6 +12,27 @@ jobs:
         id: tag
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
+      # The formula is built from the tag alone, so a tag cut from a commit
+      # that predates its own VERSION bump would ship a binary reporting the
+      # wrong version — and install.sh compares that string against the
+      # release tag to decide whether to skip a reinstall.  That happened with
+      # v0.9.0.  Fail here, before the tap is touched.
+      - name: Verify cage.sh VERSION matches the release tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          ver="$(curl -fsSL "https://github.com/pacificsky/cage/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz" \
+                 | tar -xzO --wildcards '*/cage.sh' \
+                 | sed -n 's/^VERSION="\(.*\)"/\1/p' | head -1)"
+          if [ -z "$ver" ]; then
+            echo "::error::could not read VERSION from cage.sh in tag ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          if [ "$ver" != "$tag" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} has VERSION=\"$ver\" in cage.sh (expected \"$tag\"). Re-tag from a commit with the matching bump."
+            exit 1
+          fi
+          echo "cage.sh VERSION=\"$ver\" matches tag ${GITHUB_REF_NAME}"
+
       - name: Download tarball and compute SHA256
         id: sha
         run: |

--- a/cage.sh
+++ b/cage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="0.9.0"
+VERSION="0.10.0"
 IMAGE="${CAGE_IMAGE:-ghcr.io/pacificsky/devcontainer-lite:latest}"
 HOME_VOL="cage-home"
 COLIMA_PROFILE="cage"

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -352,13 +352,13 @@ test_help_long_flag() {
     local out; out="$(run_cage --help)";  assert_contains "$out" "Usage:"
 }
 test_version_V() {
-    local out; out="$(run_cage -V)";      assert_contains "$out" "cage 0.9.0"
+    local out; out="$(run_cage -V)";      assert_contains "$out" "cage 0.10.0"
 }
 test_version_long() {
-    local out; out="$(run_cage --version)"; assert_contains "$out" "cage 0.9.0"
+    local out; out="$(run_cage --version)"; assert_contains "$out" "cage 0.10.0"
 }
 test_version_command() {
-    local out; out="$(run_cage version)"; assert_contains "$out" "cage 0.9.0"
+    local out; out="$(run_cage version)"; assert_contains "$out" "cage 0.10.0"
 }
 test_help_mentions_dstart() {
     local out; out="$(run_cage help)"


### PR DESCRIPTION
## Bump

Two features have landed since the last release, so this is a minor bump to **0.10.0**:

| | |
|---|---|
| #32 | README: injected env vars, Linux SSH agent path |
| #33 | `cage dstart` — docker-enabled cages |
| #34 | Mount files + `-v` documented |
| #35 | `path::opts` same-path-with-options |

## The guard, and why

**`v0.9.0` is mis-tagged.** The tag points at `16e0d53` (#31), where `cage.sh` still reads `VERSION="0.8.0"` — so that release installs a binary reporting `cage 0.8.0`. It has a concrete consequence beyond cosmetics: `install.sh` reads that exact string out of the installed binary and compares it to the latest release tag to decide whether to skip a reinstall. `0.8.0` never equals `0.9.0`, so it reinstalls on every single run instead of reporting "already installed".

Nothing prevented this. `update-homebrew.yml` builds the formula from the tag name and tarball SHA and never reads `cage.sh`, so the tag and the version string are two independent facts kept in sync only by discipline.

This adds a step that reads `cage.sh` out of the release tarball and fails **before** the tap is touched, so a mismatched tag cannot reach users:

```
::error::tag v0.9.0 has VERSION="0.8.0" in cage.sh (expected "0.9.0"). Re-tag from a commit with the matching bump.
```

Verified locally against tarballs shaped like GitHub's (`cage-<ver>/cage.sh`): passes on a matching tag, and fails on a replay of the actual v0.9.0 mistake.

## Notes

- **The `v0.9.0` tag is left alone.** Re-pointing it would invalidate the SHA256 already baked into the published Homebrew formula and break anyone pinning `CAGE_VERSION=0.9.0`. This release supersedes it.
- The three `cage <version>` assertions in `tests/test_cage.sh` stay hardcoded rather than reading `VERSION` from `cage.sh`. Reading it would make them tautological; the point is that a bump has to be deliberate.
- `tests/test_install.sh` hardcodes `0.9.0`/`0.8.0`/`0.7.0` as *synthetic fixtures* for upgrade/skip logic, not assertions about the current version, so they're untouched. 14/14 still pass.

**Merge this before tagging** — the tag must point at the merged commit, which is exactly the ordering that went wrong for v0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmBvXnMCMwqzCgHYrRcozz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application version to 0.10.0.

- **Bug Fixes**
  - Release packaging now verifies that the archive version matches the release tag before publishing updates.
  - Added validation for missing or mismatched version information to prevent incorrect releases.

- **Tests**
  - Updated version command checks to reflect version 0.10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->