### PR TITLE
Fix errors in seeding /home/vscode when starting cage.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Deterministic: `cage-<dirname>-<8char-sha256-of-absolute-path>`. Example: `/User
 
 ### Seed Directory
 
-`~/.config/cage/home/` contents are copied into `/home/vscode/` on new container creation using `cp -n` (no-clobber). Existing files in the shared volume are never overwritten. The seed runs on every path that creates a new container: `start` (new), `restart`, and `upgrade`.
+`~/.config/cage/home/` contents are copied into `/home/vscode/` on new container creation. The copy runs as root (`docker cp` stages the seed root-owned, and 0600 seeds must still be readable), with the staging dir first chown'd to `/home/vscode`'s owner and `cp -rp --update=none` (no-clobber) preserving that ownership — existing files in the shared volume are never overwritten. The seed runs on every path that creates a new container: `start` (new), `restart`, and `upgrade`.
 
 ### Environment Files
 

--- a/cage.sh
+++ b/cage.sh
@@ -298,8 +298,12 @@ build_mount_args() {
 }
 
 # Copy seed files from ~/.config/cage/home/ into the container's /home/vscode/.
-# Uses cp -n (no-clobber) so existing files in the volume are never overwritten.
-# The container must be in "created" (stopped) state.  This function starts
+# docker cp stages the seed root-owned, so the copy runs as root — a non-root
+# exec can't read restrictive-mode seeds (0600 keys/creds). The staging dir is
+# first chown'd to whoever owns /home/vscode and cp -p preserves that, so
+# seeded files land owned by the container user rather than root.
+# --update=none (no-clobber) means existing files in the volume are never
+# overwritten. The container must be in "created" (stopped) state.  This function starts
 # it (detached) so docker exec can run, and returns 0.  If there is nothing
 # to seed it returns 1 and leaves the container stopped.
 seed_home() {
@@ -312,7 +316,7 @@ seed_home() {
     info "Seeding home directory from $seed_dir"
     $DOCKER cp "$seed_dir/." "$name:/tmp/cage-seed"
     $DOCKER start "$name"
-    $DOCKER exec -u root "$name" sh -c 'cp -r --update=none /tmp/cage-seed/. /home/vscode/ && rm -rf /tmp/cage-seed'
+    $DOCKER exec -u root "$name" sh -c 'chown -R "$(stat -c %u:%g /home/vscode)" /tmp/cage-seed && cp -rp --update=none /tmp/cage-seed/. /home/vscode/ && rm -rf /tmp/cage-seed'
     return 0
 }
 

--- a/cage.sh
+++ b/cage.sh
@@ -312,7 +312,7 @@ seed_home() {
     info "Seeding home directory from $seed_dir"
     $DOCKER cp "$seed_dir/." "$name:/tmp/cage-seed"
     $DOCKER start "$name"
-    $DOCKER exec "$name" sh -c 'cp -rn /tmp/cage-seed/. /home/vscode/ && rm -rf /tmp/cage-seed'
+    $DOCKER exec -u root "$name" sh -c 'cp -r --update=none /tmp/cage-seed/. /home/vscode/ && rm -rf /tmp/cage-seed'
     return 0
 }
 

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -1424,7 +1424,7 @@ test_start_seeds_home_when_seed_dir_exists() {
 
     local calls; calls="$(mock_calls)"
     assert_contains "$calls" "/tmp/cage-seed" "seed temp dir used"
-    assert_contains "$calls" "cp -rn /tmp/cage-seed/. /home/vscode/" "cp -rn in exec"
+    assert_contains "$calls" "cp -rp --update=none /tmp/cage-seed/. /home/vscode/" "no-clobber cp in exec"
 
     rm -rf "$HOME/.config/cage/home"
 }


### PR DESCRIPTION
Before:
```
Successfully copied 17.5MB to cage-invoice-generator-41069e43:/tmp/cage-seed
cage-invoice-generator-41069e43
cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead
cp: cannot stat '/home/vscode/.': Permission denied
═══════════════════════════════════════════════════════════════
  ▶  ENTERING CAGE: cage-invoice-generator-41069e43
  ▶  Type 'exit' or press Ctrl+D to return to host
═══════════════════════════════════════════════════════════════
```

After:
```
Successfully copied 17.5MB to cage-invoice-generator-41069e43:/tmp/cage-seed
cage-invoice-generator-41069e43
═══════════════════════════════════════════════════════════════
  ▶  ENTERING CAGE: cage-invoice-generator-41069e43
  ▶  Type 'exit' or press Ctrl+D to return to host
═══════════════════════════════════════════════════════════════
```

Tested on Ubuntu 22.04 and not elsewhere, but these commands run inside the container, so maybe it's fine? I don't see permission issues on `/home/vscode` inside the cage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home-directory seeding to reliably copy files without overwriting existing user files.
  * Seeded files now preserve the expected ownership and permissions.
  * Temporary setup files continue to be cleaned up automatically.

* **Documentation**
  * Clarified the seeding behavior, including supported seed paths and file ownership handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->