### PR TITLE
Mount a shared cage-brew volume at /home/linuxbrew

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Deterministic: `cage-<dirname>-<8char-sha256-of-absolute-path>`. Example: `/User
 |------|-----------|------|---------|
 | `$PROJECT_DIR` | `$PROJECT_DIR` | rw | Same absolute path — error messages match host |
 | `cage-home` (shared Docker volume) | `/home/vscode` | rw | Shared home dir across all cages (Claude config, creds, shell state) |
+| `cage-brew` (shared Docker volume) | `/home/linuxbrew` | rw | Persistent Homebrew prefix; ownership comes from the image (baked-in vscode-owned dir + brew shim chown fallback), cage only mounts it |
 | SSH agent socket | `/run/host-services/ssh-auth.sock` | rw | SSH agent forwarding (Docker Desktop) |
 
 ### Subcommands
@@ -36,8 +37,8 @@ Deterministic: `cage-<dirname>-<8char-sha256-of-absolute-path>`. Example: `/User
 - `cage.sh dstart` — docker-enabled start (Linux: host socket; macOS: colima `cage` VM)
 - `cage.sh stop` — stop container
 - `cage.sh rm` — stop and remove container
-- `cage.sh rmconfig` — stop all containers and remove shared home volume
-- `cage.sh obliterate` — remove all cage containers and shared home volume
+- `cage.sh rmconfig` — stop all containers and remove the shared volumes (home, brew)
+- `cage.sh obliterate` — remove all cage containers and the shared volumes (home, brew)
 - `cage.sh status` — show state, ports (recorded config when stopped), and extra mounts
 - `cage.sh list` — list all cage containers
 - `cage.sh shell` — open additional shell in running container
@@ -120,7 +121,7 @@ The image split: `restart` restores `cage.image` and recreates *without pulling*
 `cage dstart` creates a container that can run docker/compose. Mode is a creation-time property recorded via the `cage.docker` label (`host` or `colima`).
 
 - **Linux (`host`)**: mounts the host docker socket into the cage (trusted — a red warning banner is printed). Not contained.
-- **macOS (`colima`)**: provisions a dedicated colima VM (profile `cage`) via `setup_colima_cage`, mounting only `CAGE_SRC_ROOT`. It validates up front that `CAGE_SRC_ROOT` exists (a missing root gets a "create it or set CAGE_SRC_ROOT" error, checked before the project-inside-root check so a typo'd config root isn't reported as "move the project"). Named volumes are per-daemon, so VM-resident cages share a *separate* `cage-home` from plain cages — the first dstart starts with a fresh (seeded) home, and `rmconfig`/`obliterate` remove the volume on both daemons. `DOCKER_HOST` is retargeted to `~/.colima/cage/docker.sock` (`COLIMA_CAGE_SOCK`) so all docker commands for that cage hit the VM's daemon.
+- **macOS (`colima`)**: provisions a dedicated colima VM (profile `cage`) via `setup_colima_cage`, mounting only `CAGE_SRC_ROOT`. It validates up front that `CAGE_SRC_ROOT` exists (a missing root gets a "create it or set CAGE_SRC_ROOT" error, checked before the project-inside-root check so a typo'd config root isn't reported as "move the project"). Named volumes are per-daemon, so VM-resident cages share *separate* `cage-home`/`cage-brew` volumes from plain cages — the first dstart starts with a fresh (seeded) home, and `rmconfig`/`obliterate` remove the volumes on both daemons. `DOCKER_HOST` is retargeted to `~/.colima/cage/docker.sock` (`COLIMA_CAGE_SOCK`) so all docker commands for that cage hit the VM's daemon.
 - **Cross-daemon routing**: `route_to_container` locates which daemon owns a container so `stop`/`status`/`shell`/etc. reach the cage VM's daemon on macOS. `cmd_upgrade` routes *before* pulling so the pull lands on the daemon that owns the container. When a colima cage VM exists but is down, `cage_vm_down_hint` appends a "colima start --profile cage" hint to "No container" errors (`stop`/`rm`/`restart`/`status`/`upgrade`).
 - **Mode preservation**: `preserve_docker_mode` reads the `cage.docker` label so `restart`/`upgrade` recreate the container in the same mode.
 - **Multi-daemon housekeeping**: `list`/`obliterate`/`rmconfig` iterate both daemons; macOS teardown suggests `colima delete --profile cage`.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Running `cage start` again from the same directory re-attaches to the existing c
 | `cage status` | Show container name, state, port mappings, and extra mounts |
 | `cage list` | List all cage containers across projects |
 | `cage shell` | Open an additional shell in a running container |
-| `cage rmconfig` | Stop all containers and remove shared home volume |
-| `cage obliterate` | Remove all cage containers and shared home volume |
+| `cage rmconfig` | Stop all containers and remove the shared volumes (home, brew) |
+| `cage obliterate` | Remove all cage containers and the shared volumes (home, brew) |
 
 ## Examples
 
@@ -98,6 +98,7 @@ cage restart
 |------|-----------|---------|
 | Project directory | Same absolute path | Code editing, matching error paths |
 | `cage-home` (Docker volume) | `/home/vscode` | Shared home dir across all cages |
+| `cage-brew` (Docker volume) | `/home/linuxbrew` | Persistent Homebrew prefix shared across all cages |
 | SSH agent socket | `/run/host-services/ssh-auth.sock` (macOS) or `/tmp/ssh-agent.sock` (Linux) | SSH agent forwarding |
 
 On macOS, cage uses Docker Desktop's / Colima's SSH agent proxy. On Linux, it bind-mounts `$SSH_AUTH_SOCK` directly. `SSH_AUTH_SOCK` is set inside the container to match.
@@ -137,7 +138,9 @@ These are set automatically on every container:
 
 The `cage-home` volume is shared across all cage containers and projects. Claude credentials, git config, shell history, and tool state all live here — configure once, share everywhere.
 
-One exception: named volumes are per-daemon, and on macOS docker-enabled cages live in the cage VM's daemon — so they share a *separate* `cage-home` among themselves, not the one your plain cages use. See [Docker inside your cage](#docker-inside-your-cage-multi-service-projects).
+The `cage-brew` volume works the same way for Homebrew: the image's `brew` shim installs Homebrew into `/home/linuxbrew/.linuxbrew` on first use, and because that prefix lives on the shared volume, `brew install`s persist across containers, projects, and image upgrades. Ownership is handled by the image (it ships `/home/linuxbrew` owned by `vscode`, and the shim chowns as a fallback).
+
+One exception: named volumes are per-daemon, and on macOS docker-enabled cages live in the cage VM's daemon — so they share *separate* `cage-home` and `cage-brew` volumes among themselves, not the ones your plain cages use. See [Docker inside your cage](#docker-inside-your-cage-multi-service-projects).
 
 ### Image Updates
 

--- a/cage.sh
+++ b/cage.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 VERSION="0.11.0"
 IMAGE="${CAGE_IMAGE:-ghcr.io/pacificsky/devcontainer-lite:latest}"
 HOME_VOL="cage-home"
+BREW_VOL="cage-brew"
 COLIMA_PROFILE="cage"
 COLIMA_CAGE_SOCK="$HOME/.colima/cage/docker.sock"
 CAGE_DOCKER_MODE=""   # "", "host", or "colima" — set by dstart / preserve_docker_mode
@@ -492,9 +493,14 @@ cmd_enter() {
             fi
             info "Creating $name"
 
+            # Ownership of a fresh cage-brew volume comes from the image:
+            # devcontainer-lite ships /home/linuxbrew owned by vscode, so
+            # copy-on-first-use hands the volume over, and its brew shim
+            # chowns as a fallback.  cage just mounts and persists it.
             local -a mount_args=(
                 -v "${project_dir}:${project_dir}"
                 -v "${HOME_VOL}:/home/vscode"
+                -v "${BREW_VOL}:/home/linuxbrew"
             )
 
             # Extra mounts declared in ~/.config/cage/mounts and .cage.mounts.
@@ -751,6 +757,17 @@ cage_vm_daemon_reachable() {
     [ -S "$COLIMA_CAGE_SOCK" ]
 }
 
+# Remove one of cage's shared named volumes, reporting either way.
+remove_shared_volume() {
+    local vol="$1" desc="$2"
+    if $DOCKER volume inspect "$vol" >/dev/null 2>&1; then
+        info "Removing shared $desc volume $vol"
+        $DOCKER volume rm "$vol"
+    else
+        info "No shared $desc volume to remove"
+    fi
+}
+
 rmconfig_daemon() {
     local ids
     ids="$($DOCKER ps -a --filter "label=cage.project" -q)" || true
@@ -762,12 +779,8 @@ rmconfig_daemon() {
             echo "$running" | xargs $DOCKER stop
         fi
     fi
-    if $DOCKER volume inspect "$HOME_VOL" >/dev/null 2>&1; then
-        info "Removing shared home volume $HOME_VOL"
-        $DOCKER volume rm "$HOME_VOL"
-    else
-        info "No shared home volume to remove"
-    fi
+    remove_shared_volume "$HOME_VOL" home
+    remove_shared_volume "$BREW_VOL" brew
 }
 
 obliterate_daemon() {
@@ -779,12 +792,8 @@ obliterate_daemon() {
     else
         info "No cage containers to remove"
     fi
-    if $DOCKER volume inspect "$HOME_VOL" >/dev/null 2>&1; then
-        info "Removing shared home volume $HOME_VOL"
-        $DOCKER volume rm "$HOME_VOL"
-    else
-        info "No shared home volume to remove"
-    fi
+    remove_shared_volume "$HOME_VOL" home
+    remove_shared_volume "$BREW_VOL" brew
 }
 
 cmd_rmconfig() {
@@ -1049,8 +1058,8 @@ Commands:
   restart   Remove and recreate container from its original image, without
             updating it — use 'upgrade' for that (shared home volume,
             -p ports, and -v mounts preserved)
-  obliterate Destroy shared home volume and all cage containers (caution!!!)
-  rmconfig  Stop all containers and remove shared home volume (containers are preserved, but will be recreated with fresh home on next start)
+  obliterate Destroy shared volumes (home, brew) and all cage containers (caution!!!)
+  rmconfig  Stop all containers and remove shared volumes (home, brew); containers are preserved, but will be recreated with fresh home on next start
   update    Pull latest container image
   upgrade   Pull the latest version of the container's image and recreate
             it if newer (ports, mounts, and docker mode preserved)

--- a/cage.sh
+++ b/cage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="0.11.0"
+VERSION="0.12.0"
 IMAGE="${CAGE_IMAGE:-ghcr.io/pacificsky/devcontainer-lite:latest}"
 HOME_VOL="cage-home"
 BREW_VOL="cage-brew"

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -359,13 +359,13 @@ test_help_long_flag() {
     local out; out="$(run_cage --help)";  assert_contains "$out" "Usage:"
 }
 test_version_V() {
-    local out; out="$(run_cage -V)";      assert_contains "$out" "cage 0.11.0"
+    local out; out="$(run_cage -V)";      assert_contains "$out" "cage 0.12.0"
 }
 test_version_long() {
-    local out; out="$(run_cage --version)"; assert_contains "$out" "cage 0.11.0"
+    local out; out="$(run_cage --version)"; assert_contains "$out" "cage 0.12.0"
 }
 test_version_command() {
-    local out; out="$(run_cage version)"; assert_contains "$out" "cage 0.11.0"
+    local out; out="$(run_cage version)"; assert_contains "$out" "cage 0.12.0"
 }
 test_help_mentions_dstart() {
     local out; out="$(run_cage help)"

--- a/tests/test_cage.sh
+++ b/tests/test_cage.sh
@@ -14,6 +14,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CAGE_SH="$REPO_DIR/cage.sh"
 
+# Hermetic against the caller's environment: cage_config_get gives env vars
+# top precedence, so ambient values — e.g. when the suite runs inside a cage
+# whose env file injected CAGE_VM_* — would silently change provisioning
+# args and image choices. Tests that need one set it explicitly per call.
+unset CAGE_IMAGE CAGE_SRC_ROOT CAGE_VM_CPU CAGE_VM_MEMORY CAGE_VM_DISK
+unset DOCKER_HOST DOCKER_CONTEXT
+
 # ================================================================
 # Minimal test framework
 # ================================================================
@@ -2377,8 +2384,9 @@ test_start_no_mounts_files() {
 
     (cd "$project_dir" && run_cage start >/dev/null 2>&1 || true)
     local calls; calls="$(mock_calls)"
-    # Only cage's own two mounts (project dir and shared home) should appear.
-    assert_eq "2" "$(grep -o -- '-v ' <<<"$calls" | wc -l | tr -d ' ')" \
+    # Only cage's own three mounts (project dir, shared home, brew volume)
+    # should appear.
+    assert_eq "3" "$(grep -o -- '-v ' <<<"$calls" | wc -l | tr -d ' ')" \
         "no extra -v flags when mount files absent"
 
     rm -rf "$project_dir"
@@ -2392,7 +2400,7 @@ test_start_mounts_file_ignores_comments_and_blanks() {
     local calls; calls="$(mock_calls)"
     assert_contains "$calls" "-v /data:/data" "spec is read despite surrounding noise"
     assert_not_contains "$calls" "a comment" "comment not passed to docker"
-    assert_eq "3" "$(grep -o -- '-v ' <<<"$calls" | wc -l | tr -d ' ')" \
+    assert_eq "4" "$(grep -o -- '-v ' <<<"$calls" | wc -l | tr -d ' ')" \
         "blank lines produce no mounts"
 
     rm -rf "$project_dir"
@@ -2799,6 +2807,48 @@ test_restart_reapplies_ports_files() {
 
 
 # ================================================================
+# Tests: brew volume
+# ================================================================
+
+test_start_mounts_brew_volume() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 1 ""
+    mock_docker_response "pull" 0 ""
+    mock_docker_response "create" 0 ""
+    mock_docker_response "start" 0 ""
+    run_cage start >/dev/null 2>&1 || true
+    assert_contains "$(mock_calls)" "-v cage-brew:/home/linuxbrew" "brew volume mounted"
+}
+
+# Ownership of a fresh brew volume is the image's job (devcontainer-lite
+# ships /home/linuxbrew owned by vscode; copy-on-first-use propagates it,
+# and its brew shim chowns as a fallback) — cage only mounts the volume,
+# so there is deliberately no volume-init logic to test here.
+test_start_never_preinitializes_brew_volume() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "inspect" 1 ""
+    mock_docker_response "pull" 0 ""
+    mock_docker_response "create" 0 ""
+    mock_docker_response "start" 0 ""
+    run_cage start >/dev/null 2>&1 || true
+    local calls; calls="$(mock_calls)"
+    assert_not_contains "$calls" "volume create" "no explicit volume create"
+    assert_eq "0" "$(mock_call_count run)" "no ownership-fixup container"
+}
+
+test_rmconfig_removes_brew_volume() {
+    mock_reset
+    mock_docker_response "info" 0 ""
+    mock_docker_response "ps" 0 ""
+    mock_docker_response "volume" 0 ""
+    local out; out="$(run_cage rmconfig 2>&1)"
+    assert_contains "$out" "Removing shared brew volume" "brew volume removed"
+    assert_contains "$(mock_calls)" "volume rm cage-brew" "volume rm issued"
+}
+
+# ================================================================
 # Run all tests
 # ================================================================
 
@@ -3048,6 +3098,12 @@ main() {
     run_test test_start_ports_file_not_recorded_in_label
     run_test test_reattach_does_not_use_ports_files
     run_test test_restart_reapplies_ports_files
+
+    echo ""
+    echo "--- brew volume ---"
+    run_test test_start_mounts_brew_volume
+    run_test test_start_never_preinitializes_brew_volume
+    run_test test_rmconfig_removes_brew_volume
 
     print_summary
 }

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -184,8 +184,9 @@ cleanup_all() {
         cleanup_container "$name"
         rm -rf "$d"
     done
-    # Remove the shared home volume used by tests.
+    # Remove the shared volumes used by tests.
     $DOCKER volume rm cage-home >/dev/null 2>&1 || true
+    $DOCKER volume rm cage-brew >/dev/null 2>&1 || true
 }
 
 # ================================================================
@@ -274,6 +275,33 @@ test_shared_home_volume_persists() {
     local content
     content="$($DOCKER exec "$name" cat /home/vscode/persist.txt 2>/dev/null)" || true
     assert_eq "persist-test" "$content" "file persists across container recreate"
+
+    cleanup_container "$name"
+}
+
+test_brew_volume_mounted_and_persists() {
+    local pdir; pdir="$(make_project_dir)"
+    local name; name="$(container_name_for "$pdir")"
+
+    start_cage_in "$pdir" start
+    $DOCKER start "$name" >/dev/null 2>&1 || true
+    local mounted
+    mounted="$($DOCKER exec "$name" sh -c 'test -d /home/linuxbrew && echo yes' 2>/dev/null)" || true
+    assert_eq "yes" "$mounted" "/home/linuxbrew mounted"
+
+    local vol
+    vol="$($DOCKER volume inspect cage-brew --format '{{.Name}}' 2>/dev/null)" || true
+    assert_eq "cage-brew" "$vol" "cage-brew volume auto-created"
+
+    # Volume content survives container removal (ownership handling is the
+    # image's job — the test image has no brew shim, so root-written is fine).
+    $DOCKER exec -u 0 "$name" sh -c 'echo kept > /home/linuxbrew/persist.txt' 2>/dev/null || true
+    run_cage_in "$pdir" rm || true
+    start_cage_in "$pdir" start
+    $DOCKER start "$name" >/dev/null 2>&1 || true
+    local content
+    content="$($DOCKER exec "$name" cat /home/linuxbrew/persist.txt 2>/dev/null)" || true
+    assert_eq "kept" "$content" "brew volume content survives cage rm"
 
     cleanup_container "$name"
 }
@@ -778,6 +806,7 @@ main() {
     echo "--- volumes and mounts ---"
     run_test test_project_dir_mounted
     run_test test_shared_home_volume_persists
+    run_test test_brew_volume_mounted_and_persists
 
     echo ""
     echo "--- seed directory ---"


### PR DESCRIPTION
## Summary

- **`cage-brew` named volume** mounted at `/home/linuxbrew` on every cage (third standard mount, alongside the project dir and `cage-home`). The latest devcontainer image lazily bootstraps Homebrew into `/home/linuxbrew/.linuxbrew` on first `brew` use — with the prefix on a shared volume, installs persist across containers, projects, and image upgrades.
- **Ownership is deliberately the image's job, not cage's**: devcontainer ships `/home/linuxbrew` owned by `vscode` (docker/podman copy-on-first-use propagates that to a fresh volume), and its brew shim `chown`s as a fallback for pre-existing root-owned volumes. cage only mounts the volume — a unit test pins that cage never pre-creates or chowns it.
- **Lifecycle**: `rmconfig`/`obliterate` now remove both shared volumes (home + brew), on both daemons on macOS. Like `cage-home`, macOS colima dstart cages get their own per-daemon `cage-brew`.
- **Test hermeticity fix** (uncovered while testing this): the unit suite inherited ambient `CAGE_VM_*` env vars — e.g. injected into a cage container by the host's own cage env file — which changed colima provisioning args and broke the dstart tests mid-session. The suite now unsets `CAGE_*`/`DOCKER_HOST`/`DOCKER_CONTEXT` up front.

## Test plan

- [x] Unit suite: 170/170 (new: brew mount present, no pre-init, rmconfig removes it; hermeticity unsets)
- [x] Integration: new `test_brew_volume_mounted_and_persists` — volume auto-created, mounted, and content survives `cage rm`; runs on both Docker and Podman in CI
- [x] Manual repro of the full dstart create path via mock daemon confirms `-v cage-brew:/home/linuxbrew` on `docker create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018npPwmyr1vJFDqstbQuZZe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared Homebrew volume mounted at `/home/linuxbrew`.
  - Homebrew files persist when containers are removed and recreated.
  - macOS Colima cages use separate Homebrew storage from plain cages.
  - Released version 0.12.0.

- **Bug Fixes**
  - Cleanup commands now remove both shared home and Homebrew volumes.

- **Documentation**
  - Updated command help and usage documentation to explain Homebrew persistence and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->